### PR TITLE
modifies protocol according to github's unencrypted git deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx<2.0
-git+git://github.com/f5devcentral/f5-sphinx-theme@master#egg=f5_sphinx_theme
+git+https://github.com/f5devcentral/f5-sphinx-theme@master#egg=f5_sphinx_theme
 recommonmark
 sphinxcontrib-googleanalytics
 sphinxcontrib-addmetahtml


### PR DESCRIPTION
This adapts the dependency fetching protocol from the python's [requirements.txt](./requirements.txt) file according to GitHub's deprecation of the plain git:// protocol usage (https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git).

Without this, the command `pip install -r requirements.txt` fails as the port 9418 is now closed on github.com.